### PR TITLE
Updated ClearURLs rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following keys are supported:
 * `clean_urls_rules_file`: Path to URL cleaning rules file. It defaults to
   `$XDG_DATA_HOME/uroute/rules.json` (`$HOME/.local/share/uroute/rules.json`).
   If the file is missing or contains invalid JSON, the ClearURLs
-  [`data.min.js`](https://gitlab.com/KevinRoebert/ClearUrls/blob/master/data/data.min.json)
+  [`data.min.js`](https://gitlab.com/ClearURLs/rules/-/blob/master/data.min.json)
   is downloaded.
 
 ### `logging` section
@@ -147,4 +147,4 @@ the end.
 
 ## Thanks
 
-* [ClearURLs](https://gitlab.com/KevinRoebert/ClearUrls) for its [URL cleaning rules](https://gitlab.com/KevinRoebert/ClearUrls/blob/master/data/data.min.json).
+* [ClearURLs](https://gitlab.com/KevinRoebert/ClearUrls) for its [URL cleaning rules](https://gitlab.com/ClearURLs/rules/-/blob/master/data.min.json).

--- a/uroute/url.py
+++ b/uroute/url.py
@@ -63,17 +63,17 @@ class UrlCleaner:
         URL, written by the ClearURLs author, can be found
         [here](https://gitlab.com/KevinRoebert/ClearUrls/snippets/1834899).
         """
-        for provider in self.rules_data['providers'].values():
+        for provider in self.rules_data.get('providers', {}).values():
             if not re.match(provider['urlPattern'], url, re.IGNORECASE):
                 continue
 
             if any(
                 re.match(exc, url, re.IGNORECASE)
-                for exc in provider['exceptions']
+                for exc in provider.get('exceptions', [])
             ):
                 continue
 
-            for redir in provider['redirections']:
+            for redir in provider.get('redirections', []):
                 match = re.match(redir, url, re.IGNORECASE)
                 try:
                     if match and match.group(1):
@@ -87,7 +87,7 @@ class UrlCleaner:
             parsed_url = urlparse(url)
             query_params = parse_qsl(parsed_url.query)
 
-            for rule in provider['rules']:
+            for rule in provider.get('rules', []):
                 query_params = [
                     param for param in query_params
                     if not re.match(rule, param[0])

--- a/uroute/url.py
+++ b/uroute/url.py
@@ -23,12 +23,12 @@ class UrlCleaner:
 
     If the specified rules file path (`rules_path`) does not point to a valid
     JSON file, ClearURLs's `data.min.json
-    <https://kevinroebert.gitlab.io/ClearUrls/data/data.min.json>`_
+    <https://gitlab.com/ClearURLs/rules/-/blob/master/data.min.json>`_
     is automatically downloaded and used.
     """
 
     URL_CLEARURLS_DATA = (
-        'https://kevinroebert.gitlab.io/ClearUrls/data/data.min.json'
+        'https://rules2.clearurls.xyz/data.minify.json'
     )
 
     def __init__(self, rules_path):
@@ -52,7 +52,7 @@ class UrlCleaner:
         """Clean the given URL with the loaded rules data.
 
         The format of `rules_data` is the parsed JSON found in ClearURLs's
-        [`data.min.json`](https://kevinroebert.gitlab.io/ClearUrls/data/data.min.json)
+        [`data.min.json`](https://gitlab.com/ClearURLs/rules/-/blob/master/data.min.json)
         file.
 
         URLs matching a provider's `urlPattern` and one of that provider's


### PR DESCRIPTION
@walterl Hi, I cleaned up the ClearURLs repository a bit some time ago. The rules are now in their own repository and hosted via GitLab and GitHub Pages. The URL has therefore changed. There is now also a minified version of the rules. I replaced the URL with the GitHub Pages URL to the minified rules.

Maybe you like to test if everything still works.