### PR TITLE
Set focus to icons box by default

### DIFF
--- a/uroute/gui.py
+++ b/uroute/gui.py
@@ -317,6 +317,10 @@ class UrouteGui(Gtk.Window):  # pylint: disable=too-many-instance-attributes
             self._on_cancel_clicked(None)
         if event.keyval == Gdk.KEY_Return:
             self._on_run_clicked(None)
+        # Ctrl+L shortcut to focus the URL bar (like in web browsers)
+        if event.keyval == Gdk.KEY_l and event.state & Gdk.ModifierType.CONTROL_MASK:
+            self.url_entry.grab_focus()
+            self.url_entry.select_region(0, -1)  # Select all text
 
     def _on_window_show(self, _window):
         # Hack required because gtk

--- a/uroute/gui.py
+++ b/uroute/gui.py
@@ -232,12 +232,13 @@ class UrouteGui(Gtk.Window):  # pylint: disable=too-many-instance-attributes
     def _build_browser_buttons(self):
         # pylint: disable=attribute-defined-outside-init
         self.browser_store = Gtk.ListStore(GdkPixbuf.Pixbuf, str, str, object)
-        iconview = Gtk.IconView.new()
-        iconview.set_model(self.browser_store)
-        iconview.set_pixbuf_column(0)
-        iconview.set_text_column(1)
-        iconview.connect('item-activated', self._on_browser_icon_activated)
-        iconview.connect('selection-changed', self._on_browser_icon_selected)
+        # pylint: disable=attribute-defined-outside-init
+        self.iconview = Gtk.IconView.new()
+        self.iconview.set_model(self.browser_store)
+        self.iconview.set_pixbuf_column(0)
+        self.iconview.set_text_column(1)
+        self.iconview.connect('item-activated', self._on_browser_icon_activated)
+        self.iconview.connect('selection-changed', self._on_browser_icon_selected)
 
         default_itr = None
         default_program = self.uroute.get_program()
@@ -255,11 +256,11 @@ class UrouteGui(Gtk.Window):  # pylint: disable=too-many-instance-attributes
                 default_itr = itr
 
         if default_itr:
-            iconview.select_path(self.browser_store.get_path(default_itr))
-            self._on_browser_icon_selected(iconview)
+            self.iconview.select_path(self.browser_store.get_path(default_itr))
+            self._on_browser_icon_selected(self.iconview)
 
         scroll = Gtk.ScrolledWindow()
-        scroll.add(iconview)
+        scroll.add(self.iconview)
         return scroll
 
     def _build_command_hbox(self):
@@ -321,3 +322,5 @@ class UrouteGui(Gtk.Window):  # pylint: disable=too-many-instance-attributes
         # Hack required because gtk
         self.clean_url_btn.set_visible(not self.orig_url)
         self.restore_url_btn.set_visible(bool(self.orig_url))
+        # Set focus to the browser buttons area instead of the URL entry
+        self.iconview.grab_focus()


### PR DESCRIPTION
When the window opens, focus is set to URL text box and to get to selecting icons box, which requires pressing Tab twice to select the web browser. This patch changes the default focus to icons area.

Additionally, to allow easy access to the URL field, I've added Ctrl+L keyboard shortcut, like in major web browsers.